### PR TITLE
Duplicates fixes (task #6718)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,14 @@
     "autoload": {
         "psr-4": {
             "Qobo\\Duplicates\\": "src",
-            "Qobo\\Duplicates\\Test\\Fixture\\": "tests\\Fixture"
+            "Qobo\\Duplicates\\Test\\Fixture\\": "tests\\Fixture",
+            "CakeDC\\Users\\Test\\Fixture\\": "tests"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "Qobo\\Duplicates\\Test\\": "tests",
+            "CakeDC\\Users\\Test\\": "./vendor/cakedc/users/tests",
             "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
         }
     }

--- a/src/Filter/EndsWithFilter.php
+++ b/src/Filter/EndsWithFilter.php
@@ -18,6 +18,6 @@ final class EndsWithFilter extends AbstractFilter
      */
     public function getValue()
     {
-        return sprintf('SUBSTRING(%s, -%d, %d)', $this->get('field'), $this->get('length'), $this->get('length'));
+        return sprintf('SUBSTR(%s, -%d, %d)', $this->get('field'), $this->get('length'), $this->get('length'));
     }
 }

--- a/src/Filter/StartsWithFilter.php
+++ b/src/Filter/StartsWithFilter.php
@@ -18,6 +18,6 @@ final class StartsWithFilter extends AbstractFilter
      */
     public function getValue()
     {
-        return sprintf('SUBSTRING(%s, 1, %d)', $this->get('field'), $this->get('length'));
+        return sprintf('SUBSTR(%s, 1, %d)', $this->get('field'), $this->get('length'));
     }
 }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2,6 +2,7 @@
 namespace Qobo\Duplicates;
 
 use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * This is a duplicates rule configuration class.
@@ -42,7 +43,19 @@ final class Rule implements RuleInterface
         $this->name = $name;
 
         foreach ($config as $item) {
+            if (! isset($item['filter'])) {
+                throw new InvalidArgumentException('Rule filter name is required');
+            }
+
+            if (! is_string($item['filter'])) {
+                throw new InvalidArgumentException('Rule filter name must be a string');
+            }
+
             $className = 'Qobo\Duplicates\Filter\\' . ucfirst($item['filter']) . 'Filter';
+            if (! class_exists($className)) {
+                throw new RuntimeException(sprintf('Filter class does not exist: %s', $className));
+            }
+
             array_push($this->filters, new $className($item));
         }
     }

--- a/tests/Fixture/DuplicatesFixture.php
+++ b/tests/Fixture/DuplicatesFixture.php
@@ -1,0 +1,60 @@
+<?php
+namespace Qobo\Duplicates\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * DuplicatesFixture
+ *
+ */
+class DuplicatesFixture extends TestFixture
+{
+    public $table = 'qobo_duplicates';
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'model' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'original_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'duplicate_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'rule' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'status' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'latin1_swedish_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Init method
+     *
+     * @return void
+     */
+    public function init()
+    {
+        $this->records = [
+            [
+                'id' => '74d63566-f61c-4d7e-af66-417719c43d43',
+                'model' => 'Lorem ipsum dolor sit amet',
+                'original_id' => 'f011e0ad-be18-4d26-939e-3887178569e9',
+                'duplicate_id' => '03739537-77c6-4981-ab3b-a036ee5482a8',
+                'rule' => 'Lorem ipsum dolor sit amet',
+                'status' => 'Lorem ipsum dolor sit amet',
+                'created' => '2018-08-07 17:45:16',
+                'modified' => '2018-08-07 17:45:16'
+            ],
+        ];
+        parent::init();
+    }
+}

--- a/tests/TestCase/Filter/EndsWithFilterTest.php
+++ b/tests/TestCase/Filter/EndsWithFilterTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Qobo\Duplicates\Filter;
+
+use Cake\TestSuite\TestCase;
+use Qobo\Duplicates\Filter\EndsWithFilter;
+
+class EndsWithFilterTest extends TestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->instance = new EndsWithFilter(['field' => 'foo', 'length' => 10]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->instance);
+
+        parent::tearDown();
+    }
+
+    public function testGetValue()
+    {
+        $this->assertEquals('SUBSTR(foo, -10, 10)', $this->instance->getValue());
+    }
+}

--- a/tests/TestCase/Filter/ExactFilterTest.php
+++ b/tests/TestCase/Filter/ExactFilterTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Qobo\Duplicates\Filter;
+
+use Cake\TestSuite\TestCase;
+use Qobo\Duplicates\Filter\ExactFilter;
+
+class ExactFilterTest extends TestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->instance = new ExactFilter(['field' => 'foo']);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->instance);
+
+        parent::tearDown();
+    }
+
+    public function testGetValue()
+    {
+        $this->assertEquals('foo', $this->instance->getValue());
+    }
+}

--- a/tests/TestCase/Filter/StartsWithFilterTest.php
+++ b/tests/TestCase/Filter/StartsWithFilterTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Qobo\Duplicates\Filter;
+
+use Cake\TestSuite\TestCase;
+use Qobo\Duplicates\Filter\StartsWithFilter;
+
+class StartsWithFilterTest extends TestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->instance = new StartsWithFilter(['field' => 'foo', 'length' => 10]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->instance);
+
+        parent::tearDown();
+    }
+
+    public function testGetValue()
+    {
+        $this->assertEquals('SUBSTR(foo, 1, 10)', $this->instance->getValue());
+    }
+}

--- a/tests/TestCase/Model/Table/DuplicatesTableTest.php
+++ b/tests/TestCase/Model/Table/DuplicatesTableTest.php
@@ -1,0 +1,106 @@
+<?php
+namespace Qobo\Duplicates\Test\TestCase\Model\Table;
+
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Cake\Validation\Validator;
+use Qobo\Duplicates\Model\Table\DuplicatesTable;
+
+/**
+ * Qobo\Duplicates\Model\Table\DuplicatesTable Test Case
+ */
+class DuplicatesTableTest extends TestCase
+{
+    public $fixtures = [
+        'plugin.CakeDC/Users.users',
+        'plugin.Qobo/Duplicates.duplicates'
+    ];
+
+    /**
+     * Test subject
+     *
+     * @var \Qobo\Duplicates\Model\Table\DuplicatesTable
+     */
+    public $Duplicates;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Duplicates = TableRegistry::getTableLocator()->get('Qobo/Duplicates.Duplicates');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->Duplicates);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test initialize method
+     *
+     * @return void
+     */
+    public function testInitialize()
+    {
+        $this->assertInstanceOf(DuplicatesTable::class, $this->Duplicates);
+
+        $this->assertEquals('qobo_duplicates', $this->Duplicates->getTable());
+        $this->assertEquals('id', $this->Duplicates->getPrimaryKey());
+        $this->assertEquals('id', $this->Duplicates->getDisplayField());
+
+        $this->assertTrue($this->Duplicates->hasBehavior('Timestamp'));
+
+        $this->assertEmpty($this->Duplicates->associations()->keys());
+    }
+
+    /**
+     * Test validationDefault method
+     *
+     * @return void
+     */
+    public function testValidationDefault()
+    {
+        $this->assertInstanceOf(Validator::class, $this->Duplicates->validationDefault(new Validator()));
+    }
+
+    /**
+     * Test buildRules method
+     *
+     * @return void
+     */
+    public function testBuildRules()
+    {
+        $this->assertInstanceOf(RulesChecker::class, $this->Duplicates->buildRules(new RulesChecker()));
+    }
+
+    public function testSave()
+    {
+        $data = [
+            'model' => 'Articles',
+            'original_id' => '00000000-0000-0000-0000-000000000001',
+            'duplicate_id' => '00000000-0000-0000-0000-000000000001',
+            'rule' => 'byTitleName',
+            'status' => 'pending'
+        ];
+
+        $entity = $this->Duplicates->newEntity();
+        $entity = $this->Duplicates->patchEntity($entity, $data);
+
+        $this->assertInstanceOf(EntityInterface::class, $this->Duplicates->save($entity));
+        $this->assertEmpty(array_diff($data, $entity->toArray()));
+    }
+}

--- a/tests/TestCase/RuleTest.php
+++ b/tests/TestCase/RuleTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace Qobo\Duplicates\Filter;
+
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use Qobo\Duplicates\Filter\EndsWithFilter;
+use Qobo\Duplicates\Filter\StartsWithFilter;
+use Qobo\Duplicates\Rule;
+use RuntimeException;
+
+class RuleTest extends TestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->instance = new Rule('foobar', [
+            ['field' => 'title', 'filter' => 'startsWith', 'length' => 10],
+            ['field' => 'excerpt', 'filter' => 'endsWith', 'length' => 10]
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->instance);
+
+        parent::tearDown();
+    }
+
+    public function testConstructWithInvalidNameType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Rule(['foobar'], [
+            ['field' => 'title', 'filter' => 'startsWith', 'length' => 10]
+        ]);
+    }
+
+    public function testConstructWithInvalidNameString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Rule('  ', [
+            ['field' => 'title', 'filter' => 'startsWith', 'length' => 10]
+        ]);
+    }
+
+    public function testConstructWithoutFilterName()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Rule('foobar', [
+            ['field' => 'title', 'length' => 10]
+        ]);
+    }
+
+    public function testConstructWithInvalidFilterNameType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Rule('foobar', [
+            ['field' => 'title', 'filter' => ['startsWith'], 'length' => 10]
+        ]);
+    }
+
+    public function testConstructWithInvalidFilterName()
+    {
+        $this->expectException(RuntimeException::class);
+
+        new Rule('foobar', [
+            ['field' => 'title', 'filter' => 'invalidFilter', 'length' => 10]
+        ]);
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('foobar', $this->instance->getName());
+    }
+
+    public function testGetFilters()
+    {
+        $this->assertInternalType('array', $this->instance->getFilters());
+        $this->assertInstanceOf(StartsWithFilter::class, $this->instance->getFilters()[0]);
+        $this->assertInstanceOf(EndsWithFilter::class, $this->instance->getFilters()[1]);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -114,3 +114,6 @@ Cake\Core\Plugin::load('Qobo/' . $pluginName, ['path' => ROOT . DS, 'autoload' =
 
 Cake\Routing\DispatcherFactory::add('Routing');
 Cake\Routing\DispatcherFactory::add('ControllerFactory');
+
+// Load configuration file(s)
+Configure::load('Qobo/Duplicates.duplicates');


### PR DESCRIPTION
* Added file lock to `./bin/cake map_duplicates` shell script.
* Adjusted substring function name to sqlite supported one (`SUBSTR` is both supported by mysql and sqlite).
* Stricter `Qobo\Duplicates\Rule` constructor validation.
* Added unit tests.