### PR TITLE
Code base improvements (task #6718)

### DIFF
--- a/src/Controller/DuplicatesController.php
+++ b/src/Controller/DuplicatesController.php
@@ -55,17 +55,21 @@ class DuplicatesController extends AppController
     /**
      * View method.
      *
-     * @param string $originalId Original ID
+     * @param string $id Original ID
      * @param string $rule Rule name
      * @return \Cake\Http\Response|void
      */
-    public function view($originalId, $rule)
+    public function view($id, $rule)
     {
         $this->request->allowMethod('get');
 
-        $this->set('success', true);
-        $this->set('data', $this->Duplicates->fetchByOriginalIDAndRule($originalId, $rule));
-        $this->set('_serialize', ['success', 'data']);
+        $data = $this->Duplicates->fetchByOriginalIDAndRule($id, $rule);
+
+        $this->set('success', ! empty($data));
+        ! empty($data) ?
+            $this->set('data', $data) :
+            $this->set('error', sprintf('Failed to fetch duplicates for record with ID "%s"', $id));
+        $this->set('_serialize', ['success', 'data', 'error']);
     }
 
     /**

--- a/src/Controller/DuplicatesController.php
+++ b/src/Controller/DuplicatesController.php
@@ -117,11 +117,24 @@ class DuplicatesController extends AppController
     {
         $this->request->allowMethod('post');
 
-        $success = $this->Duplicates->mergeDuplicates($model, $id, $this->request->getData('data'));
-        $success = $this->Duplicates->deleteDuplicates($model, (array)$this->request->getData('ids'));
+        if (! $this->Duplicates->mergeDuplicates($model, $id, (array)$this->request->getData('data'))) {
+            $this->set('success', false);
+            $this->set('error', 'Failed to merge duplicates');
+            $this->set('_serialize', ['success', 'error']);
 
-        $this->set('success', $success);
-        $success ? $this->set('data', []) : $this->set('error', 'Failed to merge duplicates');
-        $this->set('_serialize', ['success', 'data', 'error']);
+            return;
+        }
+
+        if (! $this->Duplicates->deleteDuplicates($model, (array)$this->request->getData('ids'))) {
+            $this->set('success', false);
+            $this->set('error', 'Failed to delete merged duplicates');
+            $this->set('_serialize', ['success', 'error']);
+
+            return;
+        }
+
+        $this->set('success', true);
+        $this->set('data', []);
+        $this->set('_serialize', ['success', 'data']);
     }
 }

--- a/src/Filter/FilterCollection.php
+++ b/src/Filter/FilterCollection.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Duplicates\Filter;
+
+use ArrayIterator;
+use IteratorAggregate;
+
+/**
+ * This collection class is responsible for storing \Qobo\Duplicates\Filter\FilterInterface objects.
+ */
+final class FilterCollection implements IteratorAggregate
+{
+    /**
+     * Filter instances list.
+     *
+     * @var array
+     */
+    private $filters;
+
+    /**
+     * Constructor method.
+     *
+     * @param array $filters List of filter instances
+     */
+    public function __construct(FilterInterface ...$filters)
+    {
+        $this->filters = $filters;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->filters);
+    }
+}

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -114,7 +114,7 @@ final class Finder
 
         $query->select([
                 $this->table->getPrimaryKey() => sprintf('GROUP_CONCAT(%s)', $this->table->getPrimaryKey()),
-                'checksum' => $query->func()->concat($this->buildFilters())
+                'checksum' => $query->func()->concat($this->rule->buildFilters())
             ])
             ->group('checksum')
             ->having(['COUNT(*) > ' => 1, 'checksum !=' => '']);
@@ -127,21 +127,6 @@ final class Finder
         $this->setOffset($this->getOffset() + 1);
 
         return $query;
-    }
-
-    /**
-     * Builds query filters for sql CONCAT function.
-     *
-     * @return array
-     */
-    private function buildFilters()
-    {
-        $result = [];
-        foreach ($this->rule->getFilters() as $filter) {
-            $result = array_merge($result, [$filter->getValue() => 'literal']);
-        }
-
-        return $result;
     }
 
     /**

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -117,7 +117,7 @@ final class Finder
                 'checksum' => $query->func()->concat($this->rule->buildFilters())
             ])
             ->group('checksum')
-            ->having(['COUNT(*) > ' => 1, 'checksum !=' => '']);
+            ->having(['COUNT(*) > ' => 1, 'checksum !=' => ''], ['COUNT(*)' => 'integer', 'checksum' => 'string']);
 
         if (0 < $this->limit) {
             $query->limit($this->limit)

--- a/src/Model/Table/DuplicatesTable.php
+++ b/src/Model/Table/DuplicatesTable.php
@@ -219,7 +219,7 @@ class DuplicatesTable extends Table
             array_push($result['data'], [
                 'id' => $entity->get('original_id'),
                 'value' => $table->get($entity->get('original_id'))->get($table->getDisplayField()),
-                'count' => $entity->get('count')
+                'count' => (int)$entity->get('count')
             ]);
         }
 
@@ -229,7 +229,7 @@ class DuplicatesTable extends Table
     /**
      * Fetches duplicates by original id and rule name.
      *
-     * @param string $id Original id
+     * @param string $id Original ID
      * @param string $rule Rule name
      * @return array
      */

--- a/src/Model/Table/DuplicatesTable.php
+++ b/src/Model/Table/DuplicatesTable.php
@@ -150,11 +150,10 @@ class DuplicatesTable extends Table
      * Map duplicates by rule.
      *
      * @param \Qobo\Duplicates\RuleInterface $rule Rule instance
-     * @param array $ruleConfig Duplicates rule configuration
      * @param \Cake\Datasource\RepositoryInterface $table Table instance
      * @return void
      */
-    private function mapByRule(RuleInterface $rule, array $ruleConfig, RepositoryInterface $table)
+    private function mapByRule(RuleInterface $rule, RepositoryInterface $table)
     {
         $finder = new Finder($table, $rule, 10);
 

--- a/src/Model/Table/DuplicatesTable.php
+++ b/src/Model/Table/DuplicatesTable.php
@@ -342,7 +342,14 @@ class DuplicatesTable extends Table
     public function mergeDuplicates($model, $id, array $data)
     {
         $table = TableRegistry::getTableLocator()->get($model);
-        $entity = $table->get($id);
+        $entity = $table->find()
+            ->where([$table->getPrimaryKey() => $id])
+            ->first();
+
+        if (null === $entity) {
+            return false;
+        }
+
         $entity = $table->patchEntity($entity, $data);
 
         return (bool)$table->save($entity);

--- a/src/Model/Table/DuplicatesTable.php
+++ b/src/Model/Table/DuplicatesTable.php
@@ -19,6 +19,7 @@ use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
 use Qobo\Duplicates\Event\EventName;
+use Qobo\Duplicates\Filter\FilterCollection;
 use Qobo\Duplicates\Finder;
 use Qobo\Duplicates\Persister;
 use Qobo\Duplicates\Rule;
@@ -141,8 +142,12 @@ class DuplicatesTable extends Table
      */
     private function mapByModel(RepositoryInterface $table, array $config)
     {
-        foreach ($config as $ruleName => $ruleConfig) {
-            $this->mapByRule(new Rule($ruleName, $ruleConfig), $ruleConfig, $table);
+        foreach ($config as $ruleName => $filtersConfig) {
+            $filters = array_map(function ($conf) {
+                return new $conf['filter']($conf);
+            }, $filtersConfig);
+
+            $this->mapByRule(new Rule($ruleName, new FilterCollection(...$filters)), $table);
         }
     }
 

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2,6 +2,7 @@
 namespace Qobo\Duplicates;
 
 use InvalidArgumentException;
+use Qobo\Duplicates\Filter\FilterCollection;
 use Qobo\Duplicates\Filter\FilterInterface;
 use RuntimeException;
 
@@ -28,42 +29,10 @@ final class Rule implements RuleInterface
      * Constructor method.
      *
      * @param string $name Rule name
-     * @param array $config Rule configuration
+     * @param \Qobo\Duplicates\Filter\FilterCollection $filters Filters collection
      * @return void
      */
-    public function __construct($name, array $config)
-    {
-        $this->validateName($name);
-
-        $this->name = $name;
-
-        foreach ($config as $item) {
-            $this->validateFilter($item);
-
-            $className = 'Qobo\\Duplicates\\Filter\\' . ucfirst($item['filter']) . 'Filter';
-            if (! class_exists($className)) {
-                throw new RuntimeException(sprintf('Filter class "%s" does not exist', $className));
-            }
-
-            $filter = new $className($item);
-            if (! $filter instanceof FilterInterface) {
-                throw new RuntimeException(
-                    sprintf('Class "%s" must implement "%s" interface', $className, FilterInterface::class)
-                );
-            }
-
-            array_push($this->filters, $filter);
-        }
-    }
-
-    /**
-     * Rule name validator.
-     *
-     * @param string $name Validator name
-     * @return void
-     * @throws \InvalidArgumentException when name variable is not a string or is empty
-     */
-    private function validateName($name)
+    public function __construct($name, FilterCollection $filters)
     {
         if (! is_string($name)) {
             throw new InvalidArgumentException('Rule name must be a string');
@@ -72,28 +41,9 @@ final class Rule implements RuleInterface
         if ('' === trim($name)) {
             throw new InvalidArgumentException('Rule name is required');
         }
-    }
 
-    /**
-     * Rule filter validator.
-     *
-     * @param array $config Filter configuration
-     * @return void
-     * @throws \InvalidArgumentException when filter key is not defined or filter value is not a string or is empty
-     */
-    private function validateFilter(array $config)
-    {
-        if (! isset($config['filter'])) {
-            throw new InvalidArgumentException('Rule filter name is required');
-        }
-
-        if (! is_string($config['filter'])) {
-            throw new InvalidArgumentException('Rule filter name must be a string');
-        }
-
-        if ('' === trim($config['filter'])) {
-            throw new InvalidArgumentException('Rule filter name is required');
-        }
+        $this->name = $name;
+        $this->filters = $filters;
     }
 
     /**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -111,4 +111,19 @@ final class Rule implements RuleInterface
     {
         return $this->filters;
     }
+
+    /**
+     * Builds query filters.
+     *
+     * @return array
+     */
+    public function buildFilters()
+    {
+        $result = [];
+        foreach ($this->getFilters() as $filter) {
+            $result = array_merge($result, [$filter->getValue() => 'literal']);
+        }
+
+        return $result;
+    }
 }

--- a/src/Shell/MapDuplicatesShell.php
+++ b/src/Shell/MapDuplicatesShell.php
@@ -27,7 +27,7 @@ class MapDuplicatesShell extends Shell
     {
         $parser = parent::getOptionParser();
 
-        $parser->description('Map Duplicate records');
+        $parser->setDescription('Map Duplicate records');
 
         return $parser;
     }

--- a/tests/App/Model/Table/ArticlesTable.php
+++ b/tests/App/Model/Table/ArticlesTable.php
@@ -1,0 +1,17 @@
+<?php
+namespace Qobo\Duplicates\Test\App\Model\Table;
+
+use Cake\ORM\Table;
+
+class ArticlesTable extends Table
+{
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->table('articles');
+        $this->primaryKey('id');
+
+        $this->addBehavior('Timestamp');
+    }
+}

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -1,0 +1,74 @@
+<?php
+namespace Qobo\Duplicates\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Short description for class.
+ */
+class ArticlesFixture extends TestFixture
+{
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'uuid', 'null' => false],
+        'title' => ['type' => 'string', 'null' => true],
+        'excerpt' => ['type' => 'string', 'null' => true],
+        'body' => 'text',
+        'created' => ['type' => 'datetime', 'null' => false],
+        'modified' => ['type' => 'datetime', 'null' => false],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => '00000000-0000-0000-0000-000000000001',
+            'title' => 'First Article',
+            'body' => 'First Article Body',
+            'excerpt' => 'First',
+            'created' => '2018-08-10 17:33:54',
+            'modified' => '2018-08-10 17:33:54'
+        ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000002',
+            'title' => 'Second Article',
+            'body' => 'Second Article Body',
+            'excerpt' => 'Second',
+            'created' => '2018-08-10 17:33:55',
+            'modified' => '2018-08-10 17:33:55'
+        ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000003',
+            'title' => 'Third Article',
+            'body' => 'Third Article Body',
+            'excerpt' => 'Third',
+            'created' => '2018-08-10 17:33:56',
+            'modified' => '2018-08-10 17:33:56'
+        ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000004',
+            'title' => 'Fourth Article',
+            'body' => 'Fourth Article Body',
+            'excerpt' => 'Fourth',
+            'created' => '2018-08-10 17:33:57',
+            'modified' => '2018-08-10 17:33:57'
+        ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000005',
+            'title' => 'Fifth Article',
+            'body' => 'Fifth Article Body',
+            'excerpt' => 'Fifth',
+            'created' => '2018-08-10 17:33:58',
+            'modified' => '2018-08-10 17:33:58'
+        ],
+    ];
+}

--- a/tests/Fixture/DuplicatesFixture.php
+++ b/tests/Fixture/DuplicatesFixture.php
@@ -45,12 +45,12 @@ class DuplicatesFixture extends TestFixture
     {
         $this->records = [
             [
-                'id' => '74d63566-f61c-4d7e-af66-417719c43d43',
-                'model' => 'Lorem ipsum dolor sit amet',
-                'original_id' => 'f011e0ad-be18-4d26-939e-3887178569e9',
-                'duplicate_id' => '03739537-77c6-4981-ab3b-a036ee5482a8',
-                'rule' => 'Lorem ipsum dolor sit amet',
-                'status' => 'Lorem ipsum dolor sit amet',
+                'id' => '00000000-0000-0000-0000-000000000001',
+                'model' => 'Articles',
+                'original_id' => '00000000-0000-0000-0000-000000000002',
+                'duplicate_id' => '00000000-0000-0000-0000-000000000003',
+                'rule' => 'byTitle',
+                'status' => 'pending',
                 'created' => '2018-08-07 17:45:16',
                 'modified' => '2018-08-07 17:45:16'
             ],

--- a/tests/TestCase/Controller/DuplicatesControllerTest.php
+++ b/tests/TestCase/Controller/DuplicatesControllerTest.php
@@ -1,0 +1,210 @@
+<?php
+namespace Qobo\Duplicates\Test\TestCase\Controller;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\IntegrationTestCase;
+
+/**
+ * Qobo\Duplicates\Controller\DuplicatesController Test Case
+ */
+class DuplicatesControllerTest extends IntegrationTestCase
+{
+    public $fixtures = [
+        'plugin.CakeDC/Users.users',
+        'plugin.Qobo/Duplicates.articles',
+        'plugin.Qobo/Duplicates.duplicates'
+    ];
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->table = TableRegistry::getTableLocator()->get('Qobo/Duplicates.Duplicates');
+
+        $this->configRequest([
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'X-Requested-With' => 'XMLHttpRequest'
+            ]
+        ]);
+    }
+
+    public function tearDown()
+    {
+        unset($this->table);
+
+        parent::tearDown();
+    }
+
+    public function testIndexUnauthenticated()
+    {
+        $this->get('/duplicates/duplicates/items/Articles/byTitle');
+
+        $this->assertResponseCode(403);
+    }
+
+    public function testIndex()
+    {
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
+
+        $this->get('/duplicates/duplicates/items/Articles/byTitle');
+        $this->assertResponseCode(200);
+        $this->assertJson($this->_getBodyAsString());
+
+        $response = json_decode($this->_getBodyAsString());
+        $this->assertTrue($response->success);
+        $this->assertInternalType('object', $response->pagination);
+        $this->assertNotEmpty($response->pagination);
+        $this->assertInternalType('array', $response->data);
+        $this->assertNotEmpty($response->data);
+    }
+
+    public function testView()
+    {
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
+
+        $this->get('/duplicates/duplicates/view/00000000-0000-0000-0000-000000000002/byTitle');
+        $this->assertResponseCode(200);
+        $this->assertJson($this->_getBodyAsString());
+
+        $response = json_decode($this->_getBodyAsString());
+        $this->assertTrue($response->success);
+        $this->assertInternalType('object', $response->data);
+        $this->assertNotEmpty($response->data);
+        $this->assertInternalType('object', $response->data->original);
+        $this->assertInternalType('array', $response->data->duplicates);
+        $this->assertInternalType('array', $response->data->fields);
+        $this->assertInternalType('array', $response->data->virtualFields);
+    }
+
+    public function testViewWithInvalidID()
+    {
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
+
+        $this->get('/duplicates/duplicates/view/00000000-0000-0000-0000-000000000404/byTitle');
+        $this->assertResponseCode(200);
+        $this->assertJson($this->_getBodyAsString());
+
+        $response = json_decode($this->_getBodyAsString());
+        $this->assertFalse($response->success);
+        $this->assertSame(
+            'Failed to fetch duplicates for record with ID "00000000-0000-0000-0000-000000000404"',
+            $response->error
+        );
+    }
+
+    public function testDelete()
+    {
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
+
+        $data = [
+            'ids' => ['00000000-0000-0000-0000-000000000002']
+        ];
+
+        $this->_sendRequest('/duplicates/duplicates/delete/Articles', 'DELETE', json_encode($data));
+        $this->assertResponseCode(200);
+        $this->assertJson($this->_getBodyAsString());
+
+        $response = json_decode($this->_getBodyAsString());
+        $this->assertTrue($response->success);
+        $this->assertSame([], $response->data);
+    }
+
+    public function testDeleteWithInvalidID()
+    {
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
+
+        $data = [
+            'ids' => [
+                '00000000-0000-0000-0000-000000000002',
+                '00000000-0000-0000-0000-000000000001' // invalid duplicate ID
+            ]
+        ];
+
+        $this->_sendRequest('/duplicates/duplicates/delete/Articles', 'DELETE', json_encode($data));
+        $this->assertResponseCode(200);
+        $this->assertJson($this->_getBodyAsString());
+
+        $response = json_decode($this->_getBodyAsString());
+        $this->assertFalse($response->success);
+        $this->assertSame('Failed to delete duplicates', $response->error);
+    }
+
+    public function testFalsePositive()
+    {
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
+
+        $data = ['ids' => ['00000000-0000-0000-0000-000000000003']];
+
+        $this->post('/duplicates/duplicates/false-positive/byTitle', json_encode($data));
+        $this->assertResponseCode(200);
+        $this->assertJson($this->_getBodyAsString());
+
+        $response = json_decode($this->_getBodyAsString());
+        $this->assertTrue($response->success);
+        $this->assertSame([], $response->data);
+    }
+
+    public function testMerge()
+    {
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
+
+        $data = [
+            'data' => ['excerpt' => 'Third'],
+            'ids' => ['00000000-0000-0000-0000-000000000003']
+        ];
+
+        $this->post('/duplicates/duplicates/merge/Articles/00000000-0000-0000-0000-000000000002', json_encode($data));
+        $this->assertResponseCode(200);
+        $this->assertJson($this->_getBodyAsString());
+
+        $response = json_decode($this->_getBodyAsString());
+        $this->assertTrue($response->success);
+        $this->assertSame([], $response->data);
+    }
+
+    public function testMergeWithWrongID()
+    {
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
+
+        // get duplcicates count
+        $count = $this->table->find('all')->count();
+        $data = [
+            'data' => ['excerpt' => 'Third'],
+            'ids' => ['00000000-0000-0000-0000-000000000003']
+        ];
+
+        $this->post('/duplicates/duplicates/merge/Articles/00000000-0000-0000-0000-000000000404', json_encode($data));
+        $this->assertResponseCode(200);
+        $this->assertJson($this->_getBodyAsString());
+        // duplicate records were not affected
+        $this->assertSame($count, $this->table->find('all')->count());
+
+        $response = json_decode($this->_getBodyAsString());
+        $this->assertFalse($response->success);
+        $this->assertSame('Failed to merge duplicates', $response->error);
+    }
+
+    public function testMergeWithWrongDuplicateIDs()
+    {
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
+
+        // get duplcicates count
+        $count = $this->table->find('all')->count();
+        $data = [
+            'data' => ['excerpt' => 'Third'],
+            'ids' => ['00000000-0000-0000-0000-000000000404']
+        ];
+
+        $this->post('/duplicates/duplicates/merge/Articles/00000000-0000-0000-0000-000000000002', json_encode($data));
+        $this->assertResponseCode(200);
+        $this->assertJson($this->_getBodyAsString());
+        // duplicate records were not affected
+        $this->assertSame($count, $this->table->find('all')->count());
+
+        $response = json_decode($this->_getBodyAsString());
+        $this->assertFalse($response->success);
+        $this->assertSame('Failed to delete merged duplicates', $response->error);
+    }
+}

--- a/tests/TestCase/Filter/EndsWithFilterTest.php
+++ b/tests/TestCase/Filter/EndsWithFilterTest.php
@@ -28,6 +28,6 @@ class EndsWithFilterTest extends TestCase
 
     public function testGetValue()
     {
-        $this->assertEquals('SUBSTR(foo, -10, 10)', $this->instance->getValue());
+        $this->assertSame('SUBSTR(foo, -10, 10)', $this->instance->getValue());
     }
 }

--- a/tests/TestCase/Filter/ExactFilterTest.php
+++ b/tests/TestCase/Filter/ExactFilterTest.php
@@ -28,6 +28,6 @@ class ExactFilterTest extends TestCase
 
     public function testGetValue()
     {
-        $this->assertEquals('foo', $this->instance->getValue());
+        $this->assertSame('foo', $this->instance->getValue());
     }
 }

--- a/tests/TestCase/Filter/FilterCollectionTest.php
+++ b/tests/TestCase/Filter/FilterCollectionTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace Qobo\Duplicates\Filter;
+
+use Cake\TestSuite\TestCase;
+use Qobo\Duplicates\Filter\ExactFilter;
+use Qobo\Duplicates\Filter\FilterCollection;
+use Qobo\Duplicates\Filter\FilterInterface;
+
+class FilterCollectionTest extends TestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $filters = [
+            new ExactFilter(['field' => 'foo']),
+            new StartsWithFilter(['field' => 'foo']),
+            new EndsWithFilter(['field' => 'foo'])
+        ];
+        $this->instance = new FilterCollection(...$filters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->instance);
+
+        parent::tearDown();
+    }
+
+    public function testFilterInstance()
+    {
+        foreach ($this->instance as $filter) {
+            $this->assertInstanceOf(FilterInterface::class, $filter);
+        }
+    }
+}

--- a/tests/TestCase/Filter/StartsWithFilterTest.php
+++ b/tests/TestCase/Filter/StartsWithFilterTest.php
@@ -28,6 +28,6 @@ class StartsWithFilterTest extends TestCase
 
     public function testGetValue()
     {
-        $this->assertEquals('SUBSTR(foo, 1, 10)', $this->instance->getValue());
+        $this->assertSame('SUBSTR(foo, 1, 10)', $this->instance->getValue());
     }
 }

--- a/tests/TestCase/FinderTest.php
+++ b/tests/TestCase/FinderTest.php
@@ -1,0 +1,107 @@
+<?php
+namespace Qobo\Duplicates\Filter;
+
+use Cake\Datasource\ResultSetInterface;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Qobo\Duplicates\Filter\EndsWithFilter;
+use Qobo\Duplicates\Filter\FilterCollection;
+use Qobo\Duplicates\Finder;
+use Qobo\Duplicates\Rule;
+
+class FinderTest extends TestCase
+{
+    public $fixtures = ['plugin.Qobo/Duplicates.articles'];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->filters = [
+            new EndsWithFilter(['field' => 'title', 'length' => 3]),
+            new EndsWithFilter(['field' => 'excerpt', 'length' => 1])
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->filters);
+
+        parent::tearDown();
+    }
+
+    public function testOffset()
+    {
+        $finder = new Finder(
+            TableRegistry::getTableLocator()->get('Qobo/Duplicates.Articles'),
+            new Rule('foobar', new FilterCollection(...$this->filters))
+        );
+
+        $this->assertSame(0, $finder->getOffset());
+
+        $finder->setOffset(2);
+        $this->assertSame(2, $finder->getOffset());
+
+        $finder->resetOffset();
+        $this->assertSame(0, $finder->getOffset());
+    }
+
+    public function testExecute()
+    {
+        $finder = new Finder(
+            TableRegistry::getTableLocator()->get('Qobo/Duplicates.Articles'),
+            new Rule('foobar', new FilterCollection(...$this->filters))
+        );
+
+        $result = $finder->execute();
+        $this->assertInternalType('array', $result);
+        $this->assertCount(2, $result);
+
+        foreach ($result as $resultSet) {
+            $this->assertInstanceOf(ResultSetInterface::class, $resultSet);
+
+            $this->assertSame(
+                substr($resultSet->first()->get('title'), -3, 3),
+                substr($resultSet->skip(1)->first()->get('title'), -3, 3)
+            );
+
+            $this->assertSame(
+                substr($resultSet->first()->get('excerpt'), -1, 1),
+                substr($resultSet->skip(1)->first()->get('excerpt'), -1, 1)
+            );
+        }
+    }
+
+    public function testExecuteWithLimit()
+    {
+        $finder = new Finder(
+            TableRegistry::getTableLocator()->get('Qobo/Duplicates.Articles'),
+            new Rule('foobar', new FilterCollection(...$this->filters)),
+            1 // limit
+        );
+
+        $result = $finder->execute();
+        $this->assertInternalType('array', $result);
+        $this->assertCount(1, $result);
+
+        foreach ($result as $resultSet) {
+            $this->assertInstanceOf(ResultSetInterface::class, $resultSet);
+
+            $this->assertSame(
+                substr($resultSet->first()->get('title'), -3, 3),
+                substr($resultSet->skip(1)->first()->get('title'), -3, 3)
+            );
+
+            $this->assertSame(
+                substr($resultSet->first()->get('excerpt'), -1, 1),
+                substr($resultSet->skip(1)->first()->get('excerpt'), -1, 1)
+            );
+        }
+    }
+}

--- a/tests/TestCase/Model/Table/DuplicatesTableTest.php
+++ b/tests/TestCase/Model/Table/DuplicatesTableTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Qobo\Duplicates\Test\TestCase\Model\Table;
 
+use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -15,6 +17,7 @@ class DuplicatesTableTest extends TestCase
 {
     public $fixtures = [
         'plugin.CakeDC/Users.users',
+        'plugin.Qobo/Duplicates.articles',
         'plugin.Qobo/Duplicates.duplicates'
     ];
 
@@ -58,9 +61,9 @@ class DuplicatesTableTest extends TestCase
     {
         $this->assertInstanceOf(DuplicatesTable::class, $this->Duplicates);
 
-        $this->assertEquals('qobo_duplicates', $this->Duplicates->getTable());
-        $this->assertEquals('id', $this->Duplicates->getPrimaryKey());
-        $this->assertEquals('id', $this->Duplicates->getDisplayField());
+        $this->assertSame('qobo_duplicates', $this->Duplicates->getTable());
+        $this->assertSame('id', $this->Duplicates->getPrimaryKey());
+        $this->assertSame('id', $this->Duplicates->getDisplayField());
 
         $this->assertTrue($this->Duplicates->hasBehavior('Timestamp'));
 
@@ -102,5 +105,158 @@ class DuplicatesTableTest extends TestCase
 
         $this->assertInstanceOf(EntityInterface::class, $this->Duplicates->save($entity));
         $this->assertEmpty(array_diff($data, $entity->toArray()));
+    }
+
+    public function testMapDuplicates()
+    {
+        // overwrite Utils plugin configuration
+        Configure::write('CsvMigrations.modules.path', Configure::read('Duplicates.path'));
+
+        $this->assertSame([], $this->Duplicates->mapDuplicates());
+    }
+
+    public function testFetchByModelAndRule()
+    {
+        $expected = [
+            'pagination' => ['count' => 1],
+            'data' => [
+                ['id' => '00000000-0000-0000-0000-000000000002', 'value' => 'Second Article', 'count' => 1]
+            ]
+        ];
+
+        $this->assertSame($expected, $this->Duplicates->fetchByModelAndRule('Articles', 'byTitle', []));
+    }
+
+    public function testFetchByModelAndRuleWithOptions()
+    {
+        $options = ['page' => 0, 'size' => 1];
+        $expected = [
+            'pagination' => ['count' => 1],
+            'data' => [
+                ['id' => '00000000-0000-0000-0000-000000000002', 'value' => 'Second Article', 'count' => 1]
+            ]
+        ];
+
+        $this->assertSame($expected, $this->Duplicates->fetchByModelAndRule('Articles', 'byTitle', $options));
+
+        $options = ['page' => 1, 'size' => 1];
+        $expected = [
+            'pagination' => ['count' => 1],
+            'data' => [] // page 1 has no data
+        ];
+
+        $this->assertSame($expected, $this->Duplicates->fetchByModelAndRule('Articles', 'byTitle', $options));
+    }
+
+    public function testFetchByOriginalIDAndRule()
+    {
+        $result = $this->Duplicates->fetchByOriginalIDAndRule('00000000-0000-0000-0000-000000000002', 'byTitle');
+
+        $this->assertInstanceOf(EntityInterface::class, $result['original']);
+        $this->assertEquals(
+            TableRegistry::getTableLocator()
+                ->get('Articles')
+                ->get('00000000-0000-0000-0000-000000000002'),
+            $result['original']
+        );
+
+        $this->assertInstanceOf(ResultSetInterface::class, $result['duplicates']);
+        $this->assertEquals(
+            TableRegistry::getTableLocator()
+                ->get('Articles')
+                ->get('00000000-0000-0000-0000-000000000003'),
+            $result['duplicates']->first()
+        );
+
+        $this->assertSame(['id', 'title', 'excerpt', 'body', 'created', 'modified'], $result['fields']);
+
+        $this->assertSame([], $result['virtualFields']);
+    }
+
+    public function testFetchByOriginalIDAndRuleWithInvalidID()
+    {
+        $result = $this->Duplicates->fetchByOriginalIDAndRule('00000000-0000-0000-0000-000000000404', 'byTitle');
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDeleteDuplicates()
+    {
+        $ids = ['00000000-0000-0000-0000-000000000002'];
+
+        $this->assertTrue($this->Duplicates->deleteDuplicates('Articles', $ids));
+
+        $query = Tableregistry::getTableLocator()
+            ->get('Articles')
+            ->find('all')
+            ->where(['id' => $ids[0]]);
+        $this->assertTrue($query->isEmpty());
+
+        $query = $this->Duplicates->find('all')
+            ->where(['id' => '00000000-0000-0000-0000-000000000001']);
+        $this->assertTrue($query->isEmpty());
+    }
+
+    public function testDeleteDuplicatesWithInvalidID()
+    {
+        // get duplcicates count
+        $count = $this->Duplicates->find('all')->count();
+        $ids = [
+            '00000000-0000-0000-0000-000000000001' // invalid duplicate ID
+        ];
+
+        $this->assertFalse($this->Duplicates->deleteDuplicates('Articles', $ids));
+
+        // invalid duplicate ID
+        $query = TableRegistry::getTableLocator()
+            ->get('Articles')
+            ->find('all')
+            ->where(['id' => $ids[0]]);
+        $this->assertFalse($query->isEmpty());
+
+        // duplicate records were not affected
+        $this->assertSame($count, $this->Duplicates->find('all')->count());
+    }
+
+    public function testFalsePositiveByRuleAndIDs()
+    {
+        $ids = ['00000000-0000-0000-0000-000000000003'];
+
+        $this->assertTrue($this->Duplicates->falsePositiveByRuleAndIDs('byTitle', $ids));
+
+        $entity = $this->Duplicates->get('00000000-0000-0000-0000-000000000001');
+        $this->assertSame('processed', $entity->get('status'));
+    }
+
+    public function testFalsePositiveByRuleAndIDsWithInvalidID()
+    {
+        $ids = ['00000000-0000-0000-0000-000000000404'];
+        $resultSet = $this->Duplicates->find()->all();
+
+        $this->assertFalse($this->Duplicates->falsePositiveByRuleAndIDs('byTitle', $ids));
+        $this->assertEquals($resultSet, $this->Duplicates->find()->all());
+    }
+
+    public function testMergeDuplicates()
+    {
+        $id = '00000000-0000-0000-0000-000000000002';
+        $data = ['excerpt' => 'Third'];
+
+        $this->assertTrue($this->Duplicates->mergeDuplicates('Articles', $id, $data));
+        $this->assertSame(
+            $data['excerpt'],
+            TableRegistry::getTableLocator()
+                ->get('Articles')
+                ->get($id)
+                ->get('excerpt')
+        );
+    }
+
+    public function testMergeDuplicatesWithInvalidID()
+    {
+        $id = '00000000-0000-0000-0000-000000000404';
+        $data = ['excerpt' => 'Third'];
+
+        $this->assertFalse($this->Duplicates->mergeDuplicates('Articles', $id, $data));
     }
 }

--- a/tests/TestCase/PersisterTest.php
+++ b/tests/TestCase/PersisterTest.php
@@ -1,0 +1,121 @@
+<?php
+namespace Qobo\Duplicates\Filter;
+
+use Cake\Datasource\ResultSetInterface;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Qobo\Duplicates\Filter\EndsWithFilter;
+use Qobo\Duplicates\Filter\FilterCollection;
+use Qobo\Duplicates\Finder;
+use Qobo\Duplicates\Persister;
+use Qobo\Duplicates\Rule;
+
+class PersisterTest extends TestCase
+{
+    public $fixtures = [
+        'plugin.Qobo/Duplicates.articles',
+        'plugin.Qobo/Duplicates.duplicates'
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $filters = [
+            new EndsWithFilter(['field' => 'title', 'length' => 3]),
+            new EndsWithFilter(['field' => 'excerpt', 'length' => 1])
+        ];
+        $this->rule = new Rule('foobar', new FilterCollection(...$filters));
+        $this->table = TableRegistry::getTableLocator()->get('Articles');
+        $this->finder = new Finder($this->table, $this->rule);
+        $this->resultSet = $this->finder->execute()[0];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->resultSet);
+        unset($this->finder);
+        unset($this->table);
+        unset($this->rule);
+
+        parent::tearDown();
+    }
+
+    public function testGetOriginal()
+    {
+        $persister = new Persister($this->table, $this->rule, $this->resultSet);
+
+        $this->assertSame($this->resultSet->first(), $persister->getOriginal());
+    }
+
+    public function testIsOriginal()
+    {
+        $persister = new Persister($this->table, $this->rule, $this->resultSet);
+
+        $this->assertTrue($persister->isOriginal($this->resultSet->first()));
+        $this->assertFalse($persister->isOriginal($this->resultSet->skip(1)->first()));
+    }
+
+    public function testGetErrors()
+    {
+        $persister = new Persister($this->table, $this->rule, $this->resultSet);
+
+        $this->assertEmpty($persister->getErrors());
+
+        $persister->execute();
+        $this->assertEmpty($persister->getErrors());
+    }
+
+    public function testIsPersisted()
+    {
+        $persister = new Persister($this->table, $this->rule, $this->resultSet);
+
+        $this->assertFalse($persister->isPersisted($this->table->get('00000000-0000-0000-0000-000000000001')));
+    }
+
+    public function testExecute()
+    {
+        $persister = new Persister($this->table, $this->rule, $this->resultSet);
+
+        $this->assertTrue($persister->execute());
+
+        $table = TableRegistry::getTableLocator()->get('Qobo/Duplicates.Duplicates');
+        $query = $table->find('all')
+            ->where(['model' => 'Articles']);
+
+        $this->assertFalse($query->isEmpty());
+
+        $entity = $query->first();
+        $this->assertSame('00000000-0000-0000-0000-000000000002', $entity->get('original_id'));
+        $this->assertSame('00000000-0000-0000-0000-000000000003', $entity->get('duplicate_id'));
+    }
+
+    public function testExecuteWithAlreadyPersisted()
+    {
+        $persister = new Persister(
+            $this->table,
+            new Rule('byTitle', new FilterCollection(...$this->rule->getFilters())),
+            $this->table->find()
+                ->where(['id IN' => ['00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000003']])
+                ->all()
+        );
+
+        $this->assertTrue($persister->execute());
+
+        $table = TableRegistry::getTableLocator()->get('Qobo/Duplicates.Duplicates');
+        $query = $table->find('all')
+            ->where(['model' => 'Articles']);
+
+        $this->assertFalse($query->isEmpty());
+
+        $entity = $query->first();
+        $this->assertSame('00000000-0000-0000-0000-000000000002', $entity->get('original_id'));
+        $this->assertSame('00000000-0000-0000-0000-000000000003', $entity->get('duplicate_id'));
+    }
+}

--- a/tests/TestCase/RuleTest.php
+++ b/tests/TestCase/RuleTest.php
@@ -39,7 +39,7 @@ class RuleTest extends TestCase
 
     public function testGetName()
     {
-        $this->assertEquals('foobar', $this->instance->getName());
+        $this->assertSame('foobar', $this->instance->getName());
     }
 
     public function testGetFilters()

--- a/tests/TestCase/RuleTest.php
+++ b/tests/TestCase/RuleTest.php
@@ -4,6 +4,8 @@ namespace Qobo\Duplicates\Filter;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Qobo\Duplicates\Filter\EndsWithFilter;
+use Qobo\Duplicates\Filter\FilterCollection;
+use Qobo\Duplicates\Filter\FilterInterface;
 use Qobo\Duplicates\Filter\StartsWithFilter;
 use Qobo\Duplicates\Rule;
 use RuntimeException;
@@ -17,10 +19,12 @@ class RuleTest extends TestCase
     {
         parent::setUp();
 
-        $this->instance = new Rule('foobar', [
-            ['field' => 'title', 'filter' => 'startsWith', 'length' => 10],
-            ['field' => 'excerpt', 'filter' => 'endsWith', 'length' => 10]
-        ]);
+        $filters = [
+            new StartsWithFilter(['field' => 'title', 'length' => 10]),
+            new EndsWithFilter(['field' => 'excerpt', 'length' => 10])
+        ];
+
+        $this->instance = new Rule('foobar', new FilterCollection(...$filters));
     }
 
     /**
@@ -33,51 +37,6 @@ class RuleTest extends TestCase
         parent::tearDown();
     }
 
-    public function testConstructWithInvalidNameType()
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new Rule(['foobar'], [
-            ['field' => 'title', 'filter' => 'startsWith', 'length' => 10]
-        ]);
-    }
-
-    public function testConstructWithInvalidNameString()
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new Rule('  ', [
-            ['field' => 'title', 'filter' => 'startsWith', 'length' => 10]
-        ]);
-    }
-
-    public function testConstructWithoutFilterName()
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new Rule('foobar', [
-            ['field' => 'title', 'length' => 10]
-        ]);
-    }
-
-    public function testConstructWithInvalidFilterNameType()
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new Rule('foobar', [
-            ['field' => 'title', 'filter' => ['startsWith'], 'length' => 10]
-        ]);
-    }
-
-    public function testConstructWithInvalidFilterName()
-    {
-        $this->expectException(RuntimeException::class);
-
-        new Rule('foobar', [
-            ['field' => 'title', 'filter' => 'invalidFilter', 'length' => 10]
-        ]);
-    }
-
     public function testGetName()
     {
         $this->assertEquals('foobar', $this->instance->getName());
@@ -85,8 +44,27 @@ class RuleTest extends TestCase
 
     public function testGetFilters()
     {
-        $this->assertInternalType('array', $this->instance->getFilters());
-        $this->assertInstanceOf(StartsWithFilter::class, $this->instance->getFilters()[0]);
-        $this->assertInstanceOf(EndsWithFilter::class, $this->instance->getFilters()[1]);
+        $this->assertInstanceOf(FilterCollection::class, $this->instance->getFilters());
+        foreach ($this->instance->getFilters() as $filter) {
+            $this->assertInstanceOf(FilterInterface::class, $filter);
+        }
+    }
+
+    public function testConstructWithInvalidNameType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Rule(['foobar'], new FilterCollection(...[
+            new StartsWithFilter(['field' => 'title', 'length' => 10])
+        ]));
+    }
+
+    public function testConstructWithInvalidNameString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Rule('  ', new FilterCollection(...[
+            new StartsWithFilter(['field' => 'title', 'length' => 10])
+        ]));
     }
 }

--- a/tests/TestCase/Shell/MapDuplicatesShellTest.php
+++ b/tests/TestCase/Shell/MapDuplicatesShellTest.php
@@ -1,0 +1,82 @@
+<?php
+namespace Qobo\Duplicates\Test\TestCase\Shell;
+
+use Cake\Console\ConsoleOptionParser;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Qobo\Duplicates\Shell\MapDuplicatesShell;
+
+/**
+ * Qobo\Duplicates\Shell\MapDuplicatesShell Test Case
+ */
+class MapDuplicatesShellTest extends ConsoleIntegrationTestCase
+{
+    public $fixtures = [
+        'plugin.Qobo/Duplicates.articles',
+        'plugin.Qobo/Duplicates.duplicates'
+    ];
+
+    /**
+     * ConsoleIo mock
+     *
+     * @var \Cake\Console\ConsoleIo|\PHPUnit_Framework_MockObject_MockObject
+     */
+    public $io;
+
+    /**
+     * Test subject
+     *
+     * @var \Qobo\Duplicates\Shell\MapDuplicatesShell
+     */
+    public $MapDuplicatesShell;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
+        $this->MapDuplicatesShell = new MapDuplicatesShell($this->io);
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->MapDuplicatesShell);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test getOptionParser method
+     *
+     * @return void
+     */
+    public function testGetOptionParser()
+    {
+        $this->assertInstanceOf(ConsoleOptionParser::class, $this->MapDuplicatesShell->getOptionParser());
+        $this->assertSame('Map Duplicate records', $this->MapDuplicatesShell->getOptionParser()->getDescription());
+    }
+
+    /**
+     * Test main method
+     *
+     * @return void
+     */
+    public function testMain()
+    {
+        $table = TableRegistry::getTableLocator()->get('Qobo/Duplicates.Duplicates');
+
+        $this->assertSame(null, $this->MapDuplicatesShell->main());
+        $this->assertCount(3, $table->find()->all());
+
+        debug($this->MapDuplicatesShell->main());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,6 +110,7 @@ class_alias('Qobo\\' . $pluginName . '\Test\App\Controller\AppController', 'App\
 // If plugin has routes.php/bootstrap.php then load them, otherwise don't.
 $loadPluginRoutes = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'routes.php');
 $loadPluginBootstrap = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'bootstrap.php');
+Cake\Core\Plugin::load('Qobo/Utils', ['bootstrap' => true]);
 Cake\Core\Plugin::load('Qobo/' . $pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);
 
 Cake\Routing\DispatcherFactory::add('Routing');

--- a/tests/config/Modules/Articles/config/duplicates.json
+++ b/tests/config/Modules/Articles/config/duplicates.json
@@ -1,0 +1,6 @@
+{
+    "foobar": [
+        { "field": "title", "filter": "Qobo\\Duplicates\\Filter\\EndsWithFilter", "length": 3 },
+        { "field": "excerpt", "filter": "Qobo\\Duplicates\\Filter\\EndsWithFilter", "length": 1 }
+    ]
+}


### PR DESCRIPTION
* Moved filters build logic into the `\Qobo\Duplicates\Rule` class.
* Added filter collection class that implements `IteratorAggregate`. This class is responsible for storing `\Qobo\Duplicates\Filter\FilterInterface` objects.
* Filters instantiation has been removed from Rule class. Rule class now requires `\Qobo\Duplicates\Filter\FilterCollection` during instantiation.
* Increased code coverage to over 95%.
* Duplicates JSON configuration has been adjusted and the `filter` parameter now requires the fully-qualified class name to be provided. This change allows providing custom filter classes from the application layer. See details below.

Old configuration:
```json
// duplicates.json
{
    "customRuleName": [
        { "field": "title", "filter": "endsWith", "length": 8 }
    ]
}
```

New configuration:
```json
// duplicates.json
{
    "customRuleName": [
        { "field": "title", "filter": "Qobo\\Duplicates\\Filter\\EndsWithFilter", "length": 8 }
    ]
}
```