### PR TITLE
False positive bug (task #7159)

### DIFF
--- a/src/Controller/DuplicatesController.php
+++ b/src/Controller/DuplicatesController.php
@@ -65,11 +65,9 @@ class DuplicatesController extends AppController
 
         $data = $this->Duplicates->fetchByOriginalIDAndRule($id, $rule);
 
-        $this->set('success', ! empty($data));
-        ! empty($data) ?
-            $this->set('data', $data) :
-            $this->set('error', sprintf('Failed to fetch duplicates for record with ID "%s"', $id));
-        $this->set('_serialize', ['success', 'data', 'error']);
+        $this->set('success', true);
+        $this->set('data', $data);
+        $this->set('_serialize', ['success', 'data']);
     }
 
     /**

--- a/src/Shell/MapDuplicatesShell.php
+++ b/src/Shell/MapDuplicatesShell.php
@@ -40,7 +40,7 @@ class MapDuplicatesShell extends Shell
     public function main()
     {
         try {
-            $lock = new FileLock('import_' . md5(__FILE__) . '.lock');
+            $lock = new FileLock('import_' . md5(__FILE__));
         } catch (Exception $e) {
             $this->abort($e->getMessage());
         }


### PR DESCRIPTION
This PR fixes a bug which happens when flagging a duplicate record as false positive. This is only producible when all available duplicates are selected. When false positives are done being processed, a JavaScript error is shown in the console and the duplicates UI breaks.