### PR TITLE
PHPStan / Deprecated methods (task #8244)

### DIFF
--- a/src/Controller/DuplicatesController.php
+++ b/src/Controller/DuplicatesController.php
@@ -86,7 +86,7 @@ class DuplicatesController extends AppController
     {
         $this->request->allowMethod('delete');
 
-        $table = TableRegistry::get($model);
+        $table = TableRegistry::getTableLocator()->get($model);
 
         $primaryKey = $table->getPrimaryKey();
         if (! is_string($primaryKey)) {
@@ -139,7 +139,7 @@ class DuplicatesController extends AppController
     {
         $this->request->allowMethod('post');
 
-        $table = TableRegistry::get($model);
+        $table = TableRegistry::getTableLocator()->get($model);
 
         $primaryKey = $table->getPrimaryKey();
         if (! is_string($primaryKey)) {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -88,7 +88,7 @@ final class Manager
      */
     public function __construct(RepositoryInterface $table, EntityInterface $original, array $data = [])
     {
-        $this->table = TableRegistry::get('Qobo/Duplicates.Duplicates');
+        $this->table = TableRegistry::getTableLocator()->get('Qobo/Duplicates.Duplicates');
         $this->target = $table;
         $this->original = $original;
 

--- a/tests/TestCase/Controller/DuplicatesControllerTest.php
+++ b/tests/TestCase/Controller/DuplicatesControllerTest.php
@@ -170,7 +170,7 @@ class DuplicatesControllerTest extends IntegrationTestCase
         // get duplcicates count
         $count = $this->table->find('all')->count();
 
-        $table = TableRegistry::get('Articles');
+        $table = TableRegistry::getTableLocator()->get('Articles');
         $associations = $table->associations()->keys();
 
         $data = [

--- a/tests/TestCase/ManagerTest.php
+++ b/tests/TestCase/ManagerTest.php
@@ -50,13 +50,13 @@ class ManagerTest extends TestCase
         /**
          * @var \Qobo\Duplicates\Model\Table\DuplicatesTable $table
          */
-        $table = TableRegistry::get('Qobo/Duplicates.Duplicates');
+        $table = TableRegistry::getTableLocator()->get('Qobo/Duplicates.Duplicates');
         $this->Duplicates = $table;
 
         /**
          * @var \Qobo\Duplicates\Test\App\Model\Table\ArticlesTable $table
          */
-        $table = TableRegistry::get('Articles');
+        $table = TableRegistry::getTableLocator()->get('Articles');
         $this->table = $table;
     }
 

--- a/tests/TestCase/Shell/MapDuplicatesShellTest.php
+++ b/tests/TestCase/Shell/MapDuplicatesShellTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Qobo\Duplicates\Test\TestCase\Shell;
 
+use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\ConsoleIntegrationTestCase;
@@ -19,7 +20,7 @@ class MapDuplicatesShellTest extends ConsoleIntegrationTestCase
     /**
      * ConsoleIo mock
      *
-     * @var \Cake\Console\ConsoleIo|\PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject
      */
     public $io;
 
@@ -39,7 +40,9 @@ class MapDuplicatesShellTest extends ConsoleIntegrationTestCase
     {
         parent::setUp();
         $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $this->MapDuplicatesShell = new MapDuplicatesShell($this->io);
+        if ($this->io instanceof ConsoleIo) {
+            $this->MapDuplicatesShell = new MapDuplicatesShell($this->io);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes one more PHPStan error along with some deprecated methods. At this point there is only PHPStan error under `Persister` class.