### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "optimize-autoloader": true
     },
     "require": {
-        "qobo/cakephp-utils": "dev-cakephp-v38a"
+        "qobo/cakephp-utils": "^v13.0"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "optimize-autoloader": true
     },
     "require": {
-        "qobo/cakephp-utils": "^v13.0"
+        "qobo/cakephp-utils": "^13.0"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,8 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
-        }
-    ],
     "require": {
-        "qobo/cakephp-utils": "^13.0"
+        "qobo/cakephp-utils": "dev-cakephp-v38a"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"
@@ -60,6 +54,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/src/Model/Table/DuplicatesTable.php
+++ b/src/Model/Table/DuplicatesTable.php
@@ -288,7 +288,7 @@ class DuplicatesTable extends Table
         $data = [
             'original' => $original,
             'duplicates' => $table->find()->where([$primaryKey . ' IN' => $ids])->all(),
-            'fields' => $original->visibleProperties(),
+            'fields' => $original->getVisible(),
             'virtualFields' => $original->getVirtual(),
         ];
         $event = new Event((string)EventName::DUPLICATE_AFTER_FIND(), $this, [

--- a/tests/TestCase/Controller/DuplicatesControllerTest.php
+++ b/tests/TestCase/Controller/DuplicatesControllerTest.php
@@ -12,13 +12,13 @@ class DuplicatesControllerTest extends IntegrationTestCase
     private $table;
 
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.Qobo/Duplicates.articles',
-        'plugin.Qobo/Duplicates.articles_tags',
-        'plugin.Qobo/Duplicates.authors',
-        'plugin.Qobo/Duplicates.comments',
-        'plugin.Qobo/Duplicates.duplicates',
-        'plugin.Qobo/Duplicates.tags',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Qobo/Duplicates.Articles',
+        'plugin.Qobo/Duplicates.ArticlesTags',
+        'plugin.Qobo/Duplicates.Authors',
+        'plugin.Qobo/Duplicates.Comments',
+        'plugin.Qobo/Duplicates.Duplicates',
+        'plugin.Qobo/Duplicates.Tags',
     ];
 
     public function setUp()

--- a/tests/TestCase/FinderTest.php
+++ b/tests/TestCase/FinderTest.php
@@ -11,7 +11,7 @@ use Qobo\Duplicates\Rule;
 
 class FinderTest extends TestCase
 {
-    public $fixtures = ['plugin.Qobo/Duplicates.articles'];
+    public $fixtures = ['plugin.Qobo/Duplicates.Articles'];
 
     /**
      * @var array $filters

--- a/tests/TestCase/ManagerTest.php
+++ b/tests/TestCase/ManagerTest.php
@@ -19,13 +19,13 @@ use Qobo\Duplicates\Manager;
 class ManagerTest extends TestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.Qobo/Duplicates.articles',
-        'plugin.Qobo/Duplicates.articles_tags',
-        'plugin.Qobo/Duplicates.authors',
-        'plugin.Qobo/Duplicates.comments',
-        'plugin.Qobo/Duplicates.duplicates',
-        'plugin.Qobo/Duplicates.tags',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Qobo/Duplicates.Articles',
+        'plugin.Qobo/Duplicates.ArticlesTags',
+        'plugin.Qobo/Duplicates.Authors',
+        'plugin.Qobo/Duplicates.Comments',
+        'plugin.Qobo/Duplicates.Duplicates',
+        'plugin.Qobo/Duplicates.Tags',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/DuplicatesTableTest.php
+++ b/tests/TestCase/Model/Table/DuplicatesTableTest.php
@@ -16,9 +16,9 @@ use Qobo\Duplicates\Model\Table\DuplicatesTable;
 class DuplicatesTableTest extends TestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.Qobo/Duplicates.articles',
-        'plugin.Qobo/Duplicates.duplicates',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Qobo/Duplicates.Articles',
+        'plugin.Qobo/Duplicates.Duplicates',
     ];
 
     /**

--- a/tests/TestCase/PersisterTest.php
+++ b/tests/TestCase/PersisterTest.php
@@ -33,8 +33,8 @@ class PersisterTest extends TestCase
     private $resultSet;
 
     public $fixtures = [
-        'plugin.Qobo/Duplicates.articles',
-        'plugin.Qobo/Duplicates.duplicates',
+        'plugin.Qobo/Duplicates.Articles',
+        'plugin.Qobo/Duplicates.Duplicates',
     ];
 
     /**

--- a/tests/TestCase/Shell/MapDuplicatesShellTest.php
+++ b/tests/TestCase/Shell/MapDuplicatesShellTest.php
@@ -13,8 +13,8 @@ use Qobo\Duplicates\Shell\MapDuplicatesShell;
 class MapDuplicatesShellTest extends ConsoleIntegrationTestCase
 {
     public $fixtures = [
-        'plugin.Qobo/Duplicates.articles',
-        'plugin.Qobo/Duplicates.duplicates',
+        'plugin.Qobo/Duplicates.Articles',
+        'plugin.Qobo/Duplicates.Duplicates',
     ];
 
     /**


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.

